### PR TITLE
rename DATABASE_URL to POSTGRES_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,4 +20,4 @@ AUTH_GITHUB_ID=""
 AUTH_GITHUB_SECRET=""
 
 # Drizzle
-DATABASE_URL="postgresql://postgres:password@localhost:6543/postgres"
+POSTGRES_URL="postgresql://postgres:password@localhost:6543/postgres"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     name: Deploy Database
     env:
-      DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+      POSTGRES_URL: ${{ secrets.PROD_POSTGRES_URL }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
       AUTH_SECRET: TBD
       AUTH_GITHUB_ID: TBD
       AUTH_GITHUB_SECRET: TBD
-      DATABASE_URL: ${{ secrets.DEV_DATABASE_URL }}
+      POSTGRES_URL: ${{ secrets.DEV_POSTGRES_URL }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,8 +1,8 @@
 import { type Config } from "drizzle-kit";
 
-const databaseUrl = process.env.DATABASE_URL;
+const databaseUrl = process.env.POSTGRES_URL;
 if (!databaseUrl) {
-  throw new Error("DATABASE_URL is not set");
+  throw new Error("POSTGRES_URL is not set");
 }
 
 export default {

--- a/src/env.js
+++ b/src/env.js
@@ -13,7 +13,7 @@ export const env = createEnv({
         : z.string().optional(),
     AUTH_GITHUB_ID: z.string(),
     AUTH_GITHUB_SECRET: z.string(),
-    DATABASE_URL: z.string().url(),
+    POSTGRES_URL: z.string().url(),
     NODE_ENV: z
       .enum(["development", "test", "production"])
       .default("development"),
@@ -36,7 +36,7 @@ export const env = createEnv({
     AUTH_SECRET: process.env.AUTH_SECRET,
     AUTH_GITHUB_ID: process.env.AUTH_GITHUB_ID,
     AUTH_GITHUB_SECRET: process.env.AUTH_GITHUB_SECRET,
-    DATABASE_URL: process.env.DATABASE_URL,
+    POSTGRES_URL: process.env.POSTGRES_URL,
     NODE_ENV: process.env.NODE_ENV,
   },
   /**

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -14,7 +14,7 @@ const globalForDb = globalThis as unknown as {
 
 const conn =
   globalForDb.conn ??
-  postgres(env.DATABASE_URL, { prepare: false, ssl: "require" });
+  postgres(env.POSTGRES_URL, { prepare: false, ssl: "require" });
 if (env.NODE_ENV !== "production") globalForDb.conn = conn;
 
 export const db = drizzle(conn, { schema });

--- a/start-database.sh
+++ b/start-database.sh
@@ -36,8 +36,8 @@ fi
 set -a
 source .env
 
-DB_PASSWORD=$(echo "$DATABASE_URL" | awk -F':' '{print $3}' | awk -F'@' '{print $1}')
-DB_PORT=$(echo "$DATABASE_URL" | awk -F':' '{print $4}' | awk -F'\/' '{print $1}')
+DB_PASSWORD=$(echo "$POSTGRES_URL" | awk -F':' '{print $3}' | awk -F'@' '{print $1}')
+DB_PORT=$(echo "$POSTGRES_URL" | awk -F':' '{print $4}' | awk -F'\/' '{print $1}')
 
 if [ "$DB_PASSWORD" = "password" ]; then
   echo "You are using the default database password"


### PR DESCRIPTION
Doing this because Vercel lets you easily connect to Supabase via their integration and pull credentials.  It uses `POSTGRES_URL`