### PR TITLE
chore: Switch to Blacksmith CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     env:
       # Skip env validation during CI builds
       SKIP_ENV_VALIDATION: true


### PR DESCRIPTION
Switches GitHub Actions runner from GitHub-hosted to Blacksmith for faster CI builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD infrastructure configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->