### PR TITLE
Configure pnpm minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary
- add pnpm-workspace.yaml with minimumReleaseAge: 10080

## Verification
- pnpm install --lockfile-only
- pnpm install
- pnpm lint